### PR TITLE
Print the errors to the output

### DIFF
--- a/clickhouse-repos-manager/app.py
+++ b/clickhouse-repos-manager/app.py
@@ -6,6 +6,7 @@ from logging.handlers import QueueHandler
 from queue import Queue
 from threading import Thread
 from time import sleep
+from traceback import format_exc
 from typing import Optional
 
 from flask import Flask, Response, jsonify, request, send_file
@@ -143,17 +144,17 @@ def upload_release(version_tag: str):
             version_tag, ContextHelper(), logger, request.args.getlist("binary")
         )
     except ReleaseException as e:
-        return str(e), 400
+        return format_exc(), 400
     except (BaseException, Exception) as e:
-        return str(e), 500
+        return format_exc(), 500
 
     try:
         thread = release.do(False)
     except (BaseException, Exception) as e:
         logger.error(
-            "Exception occured during the release process: %s", e.with_traceback
+            "Exception occured during the release process: %s", e
         )
-        return str(e.with_traceback), 500
+        return format_exc(), 500
 
     return Response(generate_response(thread), mimetype=mimetype, status=status)
 

--- a/clickhouse-repos-manager/repos.py
+++ b/clickhouse-repos-manager/repos.py
@@ -243,7 +243,7 @@ class Repos:
             self.logger.exception(
                 "Fail to prepare repositories, exception occure: %s", e
             )
-            raise RepoException from e
+            raise RepoException("Failed to create the repositories class") from e
 
     def add_packages(self) -> None:
         self.deb.add_packages(self.version_type, *self.additional_version_types)


### PR DESCRIPTION
It did fail silently, so it was hard to get the reason.